### PR TITLE
Remove the place suffix from the param options

### DIFF
--- a/lib/middleware/flights.js
+++ b/lib/middleware/flights.js
@@ -24,8 +24,8 @@ function getFlight(req, res, next) {
   options.country = (req.query.country && req.query.country.toUpperCase()) || COUNTRY;
   options.currency = req.query.currency || CURRENCY;
   options.locale = req.query.locale || LOCALE;
-  options.originPlace = req.query.originPlace;
-  options.destinationPlace = req.query.destinationPlace;
+  options.originPlace = req.query.origin;
+  options.destinationPlace = req.query.destination;
   options.inboundDate = req.query.inboundDate || INBOUND_DATE;
 
   options.outboundDate = req.query.outboundDate ?


### PR DESCRIPTION
I was thinking we could remove the `place` suffix from the param. Not entirely sure why flight tracker named it like that, but I was thinking it might look more clean if it were just:

`http://localhost:3000/api/v1/flights?origin=sfo&destination=anywhere`

Thoughts?