### PR TITLE
change default travel dates to "anytime"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Pass all params as query params
 - locale default (en-us)
 - origin (required)
 - destination (required)
-- inboundDate (default today)
-- outboundDate (default 7 days from today)
+- departureDate (default anytime)
+- returnDate (default anytime)
 

--- a/lib/controllers/flights.js
+++ b/lib/controllers/flights.js
@@ -4,18 +4,18 @@ import { URL } from 'url';
 import Logger from 'util/Logger';
 const log = new Logger('controllers/flights');
 
-const quoteEndpoint = `http://partners.api.skyscanner.net/apiservices/browsequotes/v1.0`;
+const QUOTE_ENDPOINT = `http://partners.api.skyscanner.net/apiservices/browsequotes/v1.0`;
 
 function getFlight(options, callback) {
   const endpoint = `
-    ${quoteEndpoint}/
+    ${QUOTE_ENDPOINT}/
     ${options.country}/
     ${options.currency}/
     ${options.locale}/
     ${options.origin}/
     ${options.destination}/
-    ${options.outboundDate}/
-    ${options.inboundDate}/
+    ${options.departureDate}/
+    ${options.returnDate}/
   `.replace(/\s/g,'');
   const url = new URL(endpoint);
 
@@ -29,7 +29,7 @@ function getFlight(options, callback) {
 
     if (response.statusCode > 300 || response.statusCode < 200) {
       log.error('getFlight', 'bad response from skyscanner', { msg: response.body, status: response.statusCode });
-      return callback(new Error('bad response from skyscanner'));
+      return callback(new Error(response.body));
     }
 
     return callback(null, JSON.parse(body));

--- a/lib/middleware/flights.js
+++ b/lib/middleware/flights.js
@@ -1,19 +1,15 @@
-import moment from 'moment';
-
 import controllers from 'controllers';
 import Logger from 'util/Logger';
 
 const log = new Logger('mw/flights');
 
-const DATE_FORMAT = `YYYY-MM-DD`;
 const LOCALE = 'en-US';
 const CURRENCY = 'usd';
 const COUNTRY = 'US';
-const INBOUND_DATE = 'anytime';
+const DEFAULT_DATE = 'anytime';
 
 function getFlight(req, res, next) {
   let options = {};
-  let date = moment(Date.now());
 
   if (!req.query.origin)
     return next(new Error('starting location missing! cannot complete query'));
@@ -26,14 +22,8 @@ function getFlight(req, res, next) {
   options.locale = req.query.locale || LOCALE;
   options.origin = req.query.origin;
   options.destination = req.query.destination;
-  options.inboundDate = req.query.inboundDate || INBOUND_DATE;
-
-  options.outboundDate = req.query.outboundDate ?
-    req.query.outboundDate : date.format(DATE_FORMAT);
-
-  options.inboundDate = req.query.inboundDate ?
-    req.query.inboundDate : date.add(7, 'days').format(DATE_FORMAT);
-
+  options.departureDate = DEFAULT_DATE;
+  options.returnDate = DEFAULT_DATE;
 
   controllers.flights.getFlight(options, (error, flight) => {
     if (error) {


### PR DESCRIPTION
**what:** update API to make queries date agnostic. API will now fetch all flights with only filters being starting airport and destination.
**why:** this will help us cater to our mission of serving up potential flights that are not based on dates or location, but based on price.